### PR TITLE
Update API with simple token-based auth

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,32 +1,56 @@
 from datetime import datetime
+from fastapi import Depends, HTTPException, status, Request
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from modal import Image, Secret, Stub, web_endpoint
 import os
+from pydantic import BaseModel
 import requests
 
+# Modal settings
 stub = Stub("simple-nanopore-api")
-
-api_image = Image.debian_slim(python_version="3.10").run_commands(
-    "pip install playwright==1.30.0",
-)
-
 api_image = Image.debian_slim().pip_install("requests==2.26.0")
+
+# FastAPI settings
+auth_scheme = HTTPBearer()
+
+
+class RunParams(BaseModel):
+    input: str
+    outdir: str
+    lineage: str = "chlorophyta_odb10"
+    platform: str = "nanopore"
+    email: str = ""
+
+
+def get_multiqc_title():
+    formatted_date = datetime.now().strftime("%Y-%m-%d")
+    return f"{formatted_date} - MultiQC Report"
 
 
 @stub.function(secret=Secret.from_name("nf-tower-secrets"), image=api_image)
-@web_endpoint()
-def run_pipeline(input: str, outdir: str, lineage: str = "chlorophyta_odb10", platform: str = "nanopore"):
-    formatted_date = datetime.now().strftime("%Y-%m-%d")
-    multiqc_title = f"{formatted_date} - MultiQC Report"
+@web_endpoint(method="POST")
+def run_pipeline(
+    params: RunParams,
+    token: HTTPAuthorizationCredentials = Depends(auth_scheme),
+):
+    if token.credentials != os.environ["AUTH_TOKEN"]:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    notification_email = params.email or os.environ.get("NOTIFICATION_EMAIL", "")
 
     data = {
         "params": {
+            "input": params.input,
+            "outdir": params.outdir,
+            "lineage": params.lineage,
+            "platform": params.platform,
             "from_email": os.environ["FROM_EMAIL"],
-            "email": os.environ["NOTIFICATION_EMAIL"],
-            "input": input,
-            "outdir": outdir,
-            "lineage": lineage,
-            "multiqc_title": multiqc_title,
-            "platform": platform,
+            "email": notification_email,
+            "multiqc_title": get_multiqc_title(),
         },
     }
 


### PR DESCRIPTION
This PR adds token-based auth to the simple endpoint we created for the Genetics team. 

It also presents a simple UI documenting how the API endpoint should be used: https://mertcelebi--simple-nanopore-api-run-pipeline.modal.run/docs

This page can also be used to trigger the API through the UI without touching curl etc.

Example curl command to trigger the API:

```
curl -d '{ "input": "<YOUR_INPUT_CSV>", "outdir": "<YOUR_OUTDIR>" }' \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <BEARER_TOKEN>" \
    -X POST <API_URL>
```